### PR TITLE
PreferenceCategory title color

### DIFF
--- a/library/src/main/java/com/afollestad/appthemeengine/prefs/ATEPreferenceCategory.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/prefs/ATEPreferenceCategory.java
@@ -1,0 +1,47 @@
+package com.afollestad.appthemeengine.prefs;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.preference.PreferenceCategory;
+import android.support.annotation.ColorInt;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.TextView;
+
+import com.afollestad.appthemeengine.Config;
+import com.afollestad.appthemeengine.R;
+
+
+public class ATEPreferenceCategory extends PreferenceCategory {
+    String ateKey;
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public ATEPreferenceCategory(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        ateKey = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ATEPreferenceCategory,0,0).getString(R.styleable.ATEPreferenceCategory_ateKey_prefCategory_textColor);
+    }
+
+    public ATEPreferenceCategory(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        ateKey = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ATEPreferenceCategory,0,0).getString(R.styleable.ATEPreferenceCategory_ateKey_prefCategory_textColor);
+    }
+
+    public ATEPreferenceCategory(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        ateKey = context.getTheme().obtainStyledAttributes(attrs, R.styleable.ATEPreferenceCategory,0,0).getString(R.styleable.ATEPreferenceCategory_ateKey_prefCategory_textColor);
+    }
+
+    public ATEPreferenceCategory(Context context, String ateKey) {
+        super(context);
+        this.ateKey = ateKey;
+    }
+
+
+    @Override
+    protected void onBindView(View view) {
+        super.onBindView(view);
+        TextView mTitle = (TextView) view.findViewById(android.R.id.title);
+        mTitle.setTextColor(Config.accentColor(view.getContext(),ateKey));
+    }
+}

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -57,4 +57,8 @@
         <attr name="ateKey_pref_multiSelect" format="string" />
     </declare-styleable>
 
+    <declare-styleable name="ATEPreferenceCategory">
+        <attr name="ateKey_prefCategory_textColor" format="string" />
+    </declare-styleable>
+
 </resources>

--- a/sample/src/main/res/xml/preferences.xml
+++ b/sample/src/main/res/xml/preferences.xml
@@ -65,4 +65,12 @@
         android:title="@string/light_status_bar_mode"
         app:ateKey_pref_list="?ate_key" />
 
+    <com.afollestad.appthemeengine.prefs.ATEPreferenceCategory
+        app:ateKey_prefCategory_textColor="?ate_key"
+        android:title="ATEPreferenceCategory">
+
+        <Preference android:title="Dummy Preference"/>
+
+    </com.afollestad.appthemeengine.prefs.ATEPreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
added ATEPreferenceCategory to set accent color on its title


BEFORE:
![screenshot_20160102-053252 1](https://cloud.githubusercontent.com/assets/14248102/12073222/0e623392-b113-11e5-9132-8a990e017588.png)


AFTER:
![screenshot_20160102-053315 1](https://cloud.githubusercontent.com/assets/14248102/12073223/1bce0c86-b113-11e5-8d0c-f547e662b330.png)
