### PR TITLE
Fixed a RuntimeException exception when pausing an ATEActivity

### DIFF
--- a/library/src/main/java/com/afollestad/appthemeengine/ATEActivity.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/ATEActivity.java
@@ -1,6 +1,7 @@
 package com.afollestad.appthemeengine;
 
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
@@ -34,7 +35,18 @@ public class ATEActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         if (ATE.didValuesChange(this, updateTime, getATEKey()))
-            recreate();
+            postRecreate();
+    }
+
+    // hack to prevent java.lang.RuntimeException: Performing pause of activity that is not resumed
+    private void postRecreate() {
+        // makes sure recreate() is called right after and not in onResume()
+        new Handler().post(new Runnable() {
+            @Override
+            public void run() {
+                recreate();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
java.lang.RuntimeException: Performing pause of activity that is not resumed

If you want to reproduce the exception on your device, just go to settings, change a theme value, go back and the open recents, so the activity gets paused.

The exception doesn't cause a crash as it is catched somewhere, so this (not very pretty) "fix" isn't really necessary.

I've also noticed, that when using this fix the previous activity will still have the old colors for one frame before it is recreated and shows the new theme. Not sure if it's worth the trade off.