### PR TITLE
Add alpha check to ATEUtil.isColorLight()

### DIFF
--- a/library/src/main/java/com/afollestad/appthemeengine/util/ATEUtil.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/util/ATEUtil.java
@@ -88,8 +88,9 @@ public final class ATEUtil {
         if (color == Color.BLACK) return false;
         else if (color == Color.WHITE || color == Color.TRANSPARENT) return true;
         final double darkness = 1 - (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255;
-        return darkness < 0.4;
+        return darkness > 0.4D && Color.alpha(color) < 129.0D || darkness < 0.4;
     }
+
 
     @ColorInt
     public static int invertColor(@ColorInt int color) {


### PR DESCRIPTION
This commit adds an alpha check.
Example:
if the color was black (hex #ff000000)
but the alpha was changed to for example 10% (#1a000000) the check would then return light, as the alpha is only the half or less (<129.0D).