### PR TITLE
Improve widget tinting for dependent tags

### DIFF
--- a/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEAutoCompleteTextView.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEAutoCompleteTextView.java
@@ -55,6 +55,7 @@ public class ATEAutoCompleteTextView extends AppCompatAutoCompleteTextView imple
 
     @Override
     public void postApply() {
+        if(!mWaitForInflate) return;
         mWaitForInflate = false;
         ATEViewUtil.init(mKeyContext, this, getContext());
         mKeyContext = null;

--- a/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEEditText.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEEditText.java
@@ -55,6 +55,7 @@ class ATEEditText extends AppCompatEditText implements ViewInterface, PostInflat
 
     @Override
     public void postApply() {
+        if(!mWaitForInflate) return;
         mWaitForInflate = false;
         ATEViewUtil.init(mKeyContext, this, getContext());
         mKeyContext = null;

--- a/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEMultiAutoCompleteTextView.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEMultiAutoCompleteTextView.java
@@ -55,6 +55,7 @@ public class ATEMultiAutoCompleteTextView extends AppCompatAutoCompleteTextView 
 
     @Override
     public void postApply() {
+        if(!mWaitForInflate) return;
         mWaitForInflate = false;
         ATEViewUtil.init(mKeyContext, this, getContext());
         mKeyContext = null;

--- a/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TagProcessor.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TagProcessor.java
@@ -33,6 +33,10 @@ public abstract class TagProcessor {
             mDark = dark;
         }
 
+        public void setColor(@ColorInt int color) {
+            mColor = color;
+        }
+
         public int getColor() {
             return mColor;
         }
@@ -110,16 +114,19 @@ public abstract class TagProcessor {
                 break;
             }
             case PRIMARY_COLOR_DEPENDENT: {
+                isDependent = true;
                 isDark = !ATEUtil.isColorLight(Config.primaryColor(context, key));
                 result = isDark ? Color.WHITE : Color.BLACK;
                 break;
             }
             case ACCENT_COLOR_DEPENDENT: {
+                isDependent = true;
                 isDark = !ATEUtil.isColorLight(Config.accentColor(context, key));
                 result = isDark ? Color.WHITE : Color.BLACK;
                 break;
             }
             case WINDOW_BG_DEPENDENT: {
+                isDependent = true;
                 isDark = !ATEUtil.isColorLight(ATEUtil.resolveColor(context, android.R.attr.windowBackground));
                 result = isDark ? Color.WHITE : Color.BLACK;
                 break;
@@ -148,16 +155,16 @@ public abstract class TagProcessor {
     public abstract void process(@NonNull Context context, @Nullable String key, @NonNull View view, @NonNull String suffix);
 
 
-    private static final String PRIMARY_COLOR = "primary_color";
-    private static final String PRIMARY_COLOR_DARK = "primary_color_dark";
-    private static final String ACCENT_COLOR = "accent_color";
-    private static final String PRIMARY_TEXT_COLOR = "primary_text";
-    private static final String PRIMARY_TEXT_COLOR_INVERSE = "primary_text_inverse";
-    private static final String SECONDARY_TEXT_COLOR = "secondary_text";
-    private static final String SECONDARY_TEXT_COLOR_INVERSE = "secondary_text_inverse";
+    protected static final String PRIMARY_COLOR = "primary_color";
+    protected static final String PRIMARY_COLOR_DARK = "primary_color_dark";
+    protected static final String ACCENT_COLOR = "accent_color";
+    protected static final String PRIMARY_TEXT_COLOR = "primary_text";
+    protected static final String PRIMARY_TEXT_COLOR_INVERSE = "primary_text_inverse";
+    protected static final String SECONDARY_TEXT_COLOR = "secondary_text";
+    protected static final String SECONDARY_TEXT_COLOR_INVERSE = "secondary_text_inverse";
 
-    private static final String PARENT_DEPENDENT = "parent_dependent";
-    private static final String PRIMARY_COLOR_DEPENDENT = "primary_color_dependent";
-    private static final String ACCENT_COLOR_DEPENDENT = "accent_color_dependent";
-    private static final String WINDOW_BG_DEPENDENT = "window_bg_dependent";
+    protected static final String PARENT_DEPENDENT = "parent_dependent";
+    protected static final String PRIMARY_COLOR_DEPENDENT = "primary_color_dependent";
+    protected static final String ACCENT_COLOR_DEPENDENT = "accent_color_dependent";
+    protected static final String WINDOW_BG_DEPENDENT = "window_bg_dependent";
 }

--- a/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TintTagProcessor.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TintTagProcessor.java
@@ -15,6 +15,7 @@ import android.widget.RadioButton;
 import android.widget.Spinner;
 import android.widget.Switch;
 
+import com.afollestad.appthemeengine.Config;
 import com.afollestad.appthemeengine.util.TextInputLayoutUtil;
 import com.afollestad.appthemeengine.util.TintHelper;
 
@@ -55,7 +56,7 @@ public class TintTagProcessor extends TagProcessor {
 
     @Override
     public void process(@NonNull Context context, @Nullable String key, @NonNull View view, @NonNull String suffix) {
-        final ColorResult result = getColorFromSuffix(context, key, view, suffix);
+        final ColorResult result = getTintColorFromSuffix(context, key, view, suffix);
         if (result == null) return;
 
         if (mSelectorMode) {
@@ -71,5 +72,23 @@ public class TintTagProcessor extends TagProcessor {
                 TextInputLayoutUtil.setAccent(til, result.getColor());
             }
         }
+    }
+
+    /**
+     * Returns the same as getColorFromSuffix, but adjusts the result of dependent colors
+     * to be the accent color (used for activated state)
+     */
+    public static ColorResult getTintColorFromSuffix(@NonNull Context context, @Nullable String key, @NonNull View view, @NonNull String suffix) {
+        ColorResult result = getColorFromSuffix(context, key, view, suffix);
+        if (result == null) return null;
+        // Tinted dependent color should be the accent color (only base color is dependent)
+        switch (suffix) {
+            case PARENT_DEPENDENT:
+            case PRIMARY_COLOR_DEPENDENT:
+            case ACCENT_COLOR_DEPENDENT:
+            case WINDOW_BG_DEPENDENT:
+                result.setColor(Config.accentColor(context, key));
+        }
+        return result;
     }
 }

--- a/sample/src/main/res/layout/fragment_misc.xml
+++ b/sample/src/main/res/layout/fragment_misc.xml
@@ -44,7 +44,7 @@
                 android:layout_marginLeft="@dimen/content_inset"
                 android:layout_marginRight="@dimen/content_inset"
                 android:hint="@string/regular_input"
-                android:tag="tint|parent_dependent,text_color|parent_dependent,text_color_hint|parent_dependent" />
+                android:tag="tint|accent_color_dependent,text_color|accent_color_dependent,text_color_hint|accent_color_dependent" />
 
         </FrameLayout>
 


### PR DESCRIPTION
This changes the following:
* `TintTagProcessor` injects the `accent_color` value into `ColorResult`: this ensures that the activated state is tinted with the accent color and only the base state is dependent
* `postApply()` will only be called once for `EditText`s: this is kind of a larger issue that still needs fixing, the quick fix here only solves a few cases
* all dependent tags now properly set the `isDependent` value and can thus be used with the `tint` tag