### PR TITLE
fixed crashes when window background is not a color resource

### DIFF
--- a/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEMultiAutoCompleteTextView.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/inflation/ATEMultiAutoCompleteTextView.java
@@ -3,6 +3,7 @@ package com.afollestad.appthemeengine.inflation;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatAutoCompleteTextView;
+import android.support.v7.widget.AppCompatMultiAutoCompleteTextView;
 import android.util.AttributeSet;
 
 import com.afollestad.appthemeengine.ATE;
@@ -12,7 +13,7 @@ import com.afollestad.appthemeengine.tagprocessors.ATEDefaultTags;
 /**
  * @author Aidan Follestad (afollestad)
  */
-public class ATEMultiAutoCompleteTextView extends AppCompatAutoCompleteTextView implements ViewInterface, PostInflationApplier {
+public class ATEMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTextView implements ViewInterface, PostInflationApplier {
 
     public ATEMultiAutoCompleteTextView(Context context) {
         super(context);

--- a/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TagProcessor.java
+++ b/library/src/main/java/com/afollestad/appthemeengine/tagprocessors/TagProcessor.java
@@ -47,8 +47,8 @@ public abstract class TagProcessor {
 
         public boolean isDark(Context context) {
             if (!mDependent) {
-                // mDark wasn't loaded, determine from window background instead.
-                final int windowBg = ATEUtil.resolveColor(context, android.R.attr.windowBackground);
+                // mDark wasn't loaded, determine from theme background color instead.
+                final int windowBg = ATEUtil.resolveColor(context, android.R.attr.colorBackground);
                 mDark = !ATEUtil.isColorLight(windowBg);
             }
             return mDark;
@@ -103,7 +103,7 @@ public abstract class TagProcessor {
                 final View firstBgView = getBackgroundView(view);
                 if (firstBgView == null) {
                     Log.d("ATETagProcessor", "No parents with color drawables as backgrounds found, falling back to windowBackground.");
-                    final int dependentColor = ATEUtil.resolveColor(context, android.R.attr.windowBackground);
+                    final int dependentColor = ATEUtil.resolveColor(context, android.R.attr.colorBackground);
                     isDark = !ATEUtil.isColorLight(dependentColor);
                     result = isDark ? Color.WHITE : Color.BLACK;
                 } else {
@@ -127,7 +127,7 @@ public abstract class TagProcessor {
             }
             case WINDOW_BG_DEPENDENT: {
                 isDependent = true;
-                isDark = !ATEUtil.isColorLight(ATEUtil.resolveColor(context, android.R.attr.windowBackground));
+                isDark = !ATEUtil.isColorLight(ATEUtil.resolveColor(context, android.R.attr.colorBackground));
                 result = isDark ? Color.WHITE : Color.BLACK;
                 break;
             }


### PR DESCRIPTION
This fixes https://github.com/afollestad/app-theme-engine/issues/99, also in order to make dialogs work please use material-dialogs with patch https://github.com/afollestad/material-dialogs/pull/1010.